### PR TITLE
Enable Path Validation

### DIFF
--- a/roles/core/tasks/main.yaml
+++ b/roles/core/tasks/main.yaml
@@ -220,7 +220,6 @@
         ssl-session-cache: "true"
         ssl-session-cache-size: "10m"
         ssl-session-tickets: "true"
-        strict-validate-path-type: "false"
 
 - name: Deploy Cert Manager
   kubernetes.core.helm:


### PR DESCRIPTION
This can be re-enabled now that ingress nginx has resolved the issue where . was not considered a valid part of a path.