### PR TITLE
Refactor DNS check script and update keepalived configuration

### DIFF
--- a/roles/keepalived/files/check_pihole.sh
+++ b/roles/keepalived/files/check_pihole.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
-# Verify the full DNS stack resolves queries end-to-end
-dig @127.0.0.1 -p 53 google.com +short +time=2 +tries=1 > /dev/null 2>&1
+# Verify both Pi-hole (port 53) and Unbound (port 5335) are responding
+dig @127.0.0.1 -p 53 google.com +short +time=1 +tries=1 > /dev/null 2>&1 \
+  && dig @127.0.0.1 -p 5335 google.com +short +time=1 +tries=1 > /dev/null 2>&1

--- a/roles/keepalived/templates/keepalived.conf.j2
+++ b/roles/keepalived/templates/keepalived.conf.j2
@@ -4,7 +4,10 @@ global_defs {
 
 vrrp_script chk_pihole {
     script "/usr/local/bin/check_pihole.sh"
-    interval 2
+    interval 3
+    timeout 2
+    fall 2
+    rise 2
     weight -60
     user root
 }

--- a/roles/pihole/defaults/main.yml
+++ b/roles/pihole/defaults/main.yml
@@ -8,6 +8,7 @@ pihole_config:
   dns.interface: "eth0"
   dns.domain.name: "lan"
   misc.dnsmasq_lines: '["local-ttl=300"]'
+  webserver.port: "80o,443os,[::]:80o,[::]:443os"
   webserver.interface.boxed: "false"
 
 pihole_groups:

--- a/roles/pihole/tasks/main.yml
+++ b/roles/pihole/tasks/main.yml
@@ -21,7 +21,7 @@
 - name: Pre-seed setupVars.conf so installer skips dialogs
   ansible.builtin.copy:
     dest: /etc/pihole/setupVars.conf
-    content: ""
+    content: "PIHOLE_DNS_1=127.0.0.1#5335\n"
     mode: '0644'
   when: not pihole_bin.stat.exists
 


### PR DESCRIPTION
- Modify check_pihole.sh to verify both Pi-hole and Unbound are responding.
- Adjust keepalived.conf.j2 to set appropriate interval, timeout, fall, and rise values.
- Update main.yml to configure webserver ports for Pi-hole.
- Pre-seed setupVars.conf with DNS settings for unattended installation.