### PR TITLE
Add dewpoint sensor exporter role for RPis

### DIFF
--- a/dewpoint.yaml
+++ b/dewpoint.yaml
@@ -1,0 +1,8 @@
+---
+- name: Deploy dewpoint sensor exporter
+  hosts: dns_servers
+  become: true
+  gather_facts: true
+  roles:
+    - role: dewpoint
+      tags: [dewpoint]

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -42,7 +42,7 @@ longhorn_version: "1.11.2"
 loki_version: "6.53.0"
 tempo_version: "1.26.5"
 otel_collector_version: "0.145.0"
-dewpoint_version: "0.1.1"
+dewpoint_version: "0.1.2"
 
 # Service configuration
 email_address: nolancooper97@gmail.com

--- a/group_vars/all.yaml
+++ b/group_vars/all.yaml
@@ -42,6 +42,7 @@ longhorn_version: "1.11.2"
 loki_version: "6.53.0"
 tempo_version: "1.26.5"
 otel_collector_version: "0.145.0"
+dewpoint_version: "0.1.1"
 
 # Service configuration
 email_address: nolancooper97@gmail.com

--- a/roles/core/files/secret-additional-scrape-config.yaml
+++ b/roles/core/files/secret-additional-scrape-config.yaml
@@ -19,3 +19,8 @@ stringData:
             - "soteria.lan:9100"
           labels:
             node_name: "Soteria"
+    - job_name: "dewpoint"
+      static_configs:
+        - targets:
+            - "castor.lan:9185"
+            - "pollux.lan:9185"

--- a/roles/dewpoint/defaults/main.yml
+++ b/roles/dewpoint/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+# Port on which the dewpoint exporter serves metrics.
+dewpoint_bind_port: 9185
+# Optional allowlist of Govee H5075 MAC addresses to export. When empty, every
+# discovered sensor in range is exported. Example: "A4:C1:38:7A:93:C3".
+dewpoint_address: ""

--- a/roles/dewpoint/handlers/main.yml
+++ b/roles/dewpoint/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart dewpoint
+  ansible.builtin.systemd:
+    name: dewpoint
+    state: restarted
+    daemon_reload: true

--- a/roles/dewpoint/tasks/main.yml
+++ b/roles/dewpoint/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+- name: Install dewpoint runtime dependencies
+  ansible.builtin.apt:
+    name:
+      - libdbus-1-3
+      - bluez
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Check installed dewpoint version
+  ansible.builtin.command: dpkg-query -W -f='${Version}' dewpoint
+  register: dewpoint_installed
+  changed_when: false
+  failed_when: false
+
+- name: Download dewpoint package
+  ansible.builtin.get_url:
+    url: "https://github.com/barrelmaker97/dewpoint/releases/download/v{{ dewpoint_version }}/dewpoint_{{ dewpoint_version }}_arm64.deb"
+    dest: "/tmp/dewpoint_{{ dewpoint_version }}_arm64.deb"
+    owner: root
+    group: root
+    mode: '0644'
+  when: dewpoint_installed.stdout != dewpoint_version
+
+- name: Install dewpoint package
+  ansible.builtin.apt:
+    deb: "/tmp/dewpoint_{{ dewpoint_version }}_arm64.deb"
+  when: dewpoint_installed.stdout != dewpoint_version
+
+- name: Create systemd drop-in directory
+  ansible.builtin.file:
+    path: /etc/systemd/system/dewpoint.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: '0755'
+
+- name: Configure dewpoint via systemd drop-in
+  ansible.builtin.template:
+    src: override.conf.j2
+    dest: /etc/systemd/system/dewpoint.service.d/override.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Restart dewpoint
+
+- name: Flush handlers to restart dewpoint before continuing
+  ansible.builtin.meta: flush_handlers
+
+- name: Ensure dewpoint is enabled and started
+  ansible.builtin.systemd:
+    name: dewpoint
+    enabled: true
+    state: started

--- a/roles/dewpoint/templates/override.conf.j2
+++ b/roles/dewpoint/templates/override.conf.j2
@@ -1,0 +1,5 @@
+[Service]
+Environment="BIND_PORT={{ dewpoint_bind_port }}"
+{% if dewpoint_address %}
+Environment="ADDRESS={{ dewpoint_address }}"
+{% endif %}


### PR DESCRIPTION
Deploy the dewpoint Govee H5075 Prometheus exporter to the dns_servers Raspberry Pis (castor, pollux) via a host-level role that installs the released arm64 .deb and manages a systemd drop-in for configuration.

Also add a 'dewpoint' scrape job to the additional-scrape-configs secret targeting both Pis on :9185, so kube-prometheus-stack collects the sensor metrics. Duplicate series (when both Pis hear the sensor) can be deduplicated with 'max by (address, name)'.