### PR TITLE
Add dewpoint PrometheusRule and Grafana dashboard

### DIFF
--- a/roles/core/files/configmap-dashboards.yaml
+++ b/roles/core/files/configmap-dashboards.yaml
@@ -13233,3 +13233,359 @@ data:
       "uid": "fLi0yXAWg",
       "version": 1
     }
+  dewpoint.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 1,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "unit": "celsius"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (address, name) (dewpoint_temperature_celsius)",
+              "legendFormat": "{{name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Temperature",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (address, name) (dewpoint_humidity_percent)",
+              "legendFormat": "{{name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Humidity",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "drawStyle": "line",
+                "lineInterpolation": "smooth",
+                "lineWidth": 2,
+                "fillOpacity": 10,
+                "showPoints": "never",
+                "axisPlacement": "auto",
+                "spanNulls": true
+              },
+              "unit": "dBm"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "id": 3,
+          "options": {
+            "legend": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "displayMode": "table",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "dewpoint_rssi_dbm",
+              "legendFormat": "{{name}} @ {{instance}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Signal Strength (per Pi)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "unit": "percent",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 15
+                  },
+                  {
+                    "color": "green",
+                    "value": 30
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 8
+          },
+          "id": 4,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "max by (address, name) (dewpoint_battery_percent)",
+              "legendFormat": "{{name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Battery",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "unit": "s",
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 60
+                  },
+                  {
+                    "color": "red",
+                    "value": 300
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 8
+          },
+          "id": 5,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "expr": "time() - max by (address, name) (dewpoint_last_seen_timestamp_seconds)",
+              "legendFormat": "{{name}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Last Seen",
+          "type": "stat"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 39,
+      "tags": [
+        "dewpoint",
+        "govee",
+        "bluetooth"
+      ],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Dewpoint",
+      "uid": "dewpoint",
+      "version": 1
+    }

--- a/roles/core/tasks/main.yaml
+++ b/roles/core/tasks/main.yaml
@@ -363,6 +363,11 @@
     state: present
     definition: "{{ lookup('template', 'prometheusrule-longhorn-snapshots.yaml.j2') | from_yaml }}"
 
+- name: Create Dewpoint Sensor Alerts
+  kubernetes.core.k8s:
+    state: present
+    definition: "{{ lookup('template', 'prometheusrule-dewpoint.yaml.j2') | from_yaml }}"
+
 - name: Create Discord Webhook URL Secret
   kubernetes.core.k8s:
     state: present

--- a/roles/core/templates/prometheusrule-dewpoint.yaml.j2
+++ b/roles/core/templates/prometheusrule-dewpoint.yaml.j2
@@ -1,0 +1,35 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: dewpoint
+  namespace: monitoring
+spec:
+  groups:
+    - name: dewpoint
+      rules:
+        - alert: DewpointSensorStale
+          expr: time() - max by (address, name) (dewpoint_last_seen_timestamp_seconds) > 300
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Govee sensor {% raw %}{{ $labels.name }}{% endraw %} has stopped broadcasting"
+            description: >-
+              No dewpoint exporter has received a broadcast from Govee sensor
+              {% raw %}{{ $labels.name }}{% endraw %} ({% raw %}{{ $labels.address }}{% endraw %}) in over
+              5 minutes. The H5075 broadcasts roughly every 2 seconds, so this
+              usually means the sensor is out of range of every Pi, an app has
+              opened a Bluetooth connection (which suppresses broadcasts), or the
+              battery has died.
+        - alert: DewpointSensorBatteryLow
+          expr: max by (address, name) (dewpoint_battery_percent) < 15
+          for: 1h
+          labels:
+            severity: warning
+          annotations:
+            summary: "Govee sensor {% raw %}{{ $labels.name }}{% endraw %} battery is low"
+            description: >-
+              Govee sensor {% raw %}{{ $labels.name }}{% endraw %} ({% raw %}{{ $labels.address }}{% endraw %})
+              battery is at {% raw %}{{ $value }}{% endraw %}%. Replace the coin cell
+              soon; once it dies the sensor stops broadcasting and readings are lost.


### PR DESCRIPTION
Add cluster-side monitoring for the dewpoint sensor exporter, applied by the core role (which has cluster access, unlike the host-targeted dewpoint role):

- prometheusrule-dewpoint.yaml.j2: alerts for a stale sensor (no broadcast received by any Pi in >5m) and low battery (<15%), using the 'max by (address, name)' dedup so the two-Pi redundancy doesn't cause false positives.
- dewpoint.json dashboard in the dashboards ConfigMap: temperature, humidity, per-Pi signal strength, battery, and last-seen panels.

Alert expressions validated against live Prometheus.