### PR TITLE
Enable HTTP/2 ALPN on shared Gateway via ClientTrafficPolicy

### DIFF
--- a/roles/core/tasks/main.yaml
+++ b/roles/core/tasks/main.yaml
@@ -182,6 +182,11 @@
     state: present
     template: gateway.yaml.j2
 
+- name: Create Gateway Client Traffic Policy
+  kubernetes.core.k8s:
+    state: present
+    template: clienttrafficpolicy.yaml.j2
+
 - name: Create HTTPS Redirect Route
   kubernetes.core.k8s:
     state: present

--- a/roles/core/templates/clienttrafficpolicy.yaml.j2
+++ b/roles/core/templates/clienttrafficpolicy.yaml.j2
@@ -5,6 +5,11 @@
 # covered by the same Let's Encrypt cert), to prevent HTTP/2 connection
 # coalescing routing requests to the wrong listener. Setting ALPN explicitly
 # acknowledges the overlap and restores h2 multiplexing.
+#
+# Also advertises the X25519MLKEM768 post-quantum hybrid key-exchange group
+# alongside the classic curves, so PQC-capable clients (current Chrome,
+# Firefox, etc.) negotiate quantum-resistant session keys while older clients
+# fall back to X25519/P-256 transparently.
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: ClientTrafficPolicy
 metadata:
@@ -19,3 +24,7 @@ spec:
     alpnProtocols:
       - h2
       - http/1.1
+    ecdhCurves:
+      - X25519MLKEM768
+      - X25519
+      - P-256

--- a/roles/core/templates/clienttrafficpolicy.yaml.j2
+++ b/roles/core/templates/clienttrafficpolicy.yaml.j2
@@ -1,0 +1,21 @@
+---
+# Re-enable HTTP/2 ALPN on the shared Gateway. Envoy Gateway defaults the
+# listener ALPN to HTTP/1.1 when two HTTPS listeners present certificates with
+# overlapping SANs (our apex `barrelmaker.dev` and `*.barrelmaker.dev` are
+# covered by the same Let's Encrypt cert), to prevent HTTP/2 connection
+# coalescing routing requests to the wrong listener. Setting ALPN explicitly
+# acknowledges the overlap and restores h2 multiplexing.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: ClientTrafficPolicy
+metadata:
+  name: {{ gateway_name }}-alpn
+  namespace: {{ gateway_namespace }}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: {{ gateway_name }}
+  tls:
+    alpnProtocols:
+      - h2
+      - http/1.1


### PR DESCRIPTION
Envoy Gateway disables h2 ALPN by default when two HTTPS listeners present certificates with overlapping SANs (the apex barrelmaker.dev and *.barrelmaker.dev are covered by the same wildcard cert), to prevent connection coalescing routing requests to the wrong listener. Set ALPN explicitly to acknowledge the overlap and restore HTTP/2 multiplexing.