### PR TITLE
Rename dev.obscura to devscura; add HSTS to dotfiles redirect

### DIFF
--- a/roles/workloads/files/devscura.sops.yaml
+++ b/roles/workloads/files/devscura.sops.yaml
@@ -85,7 +85,7 @@ httpRoute:
           namespace: envoy-gateway-system
           sectionName: https-wildcard
     hostnames:
-        - dev.obscura.barrelmaker.dev
+        - devscura.barrelmaker.dev
     filters:
         - type: ResponseHeaderModifier
           responseHeaderModifier:
@@ -114,6 +114,6 @@ sops:
             -----END AGE ENCRYPTED FILE-----
           recipient: age1wk5ucdcd2nzjs2ztpfhr2l0ds284p284f2c7grcmns7hsl0hp42syku7c6
     encrypted_regex: (^data|^stringData|^cluster|^secrets|^jwtSecret|^certs|^trustdinfo|^credentialsJson|.*[Pp]assword$)
-    lastmodified: "2026-06-25T01:10:50Z"
-    mac: ENC[AES256_GCM,data:2IwLMxGGbg9uMCAgZflXbqp0tePDuAMTyfLjHGgY6dT4XnAM0TL88W0njToKdVkS9oI2RHL1oOVm5DcMlwfQFLToMLc7u6shSECBH757zJKTKB5xzNO4qhc4NyUcFdNLXUL1/S181AWsulJXvONyn22dlXbvfJVUGINV3ZT2yL4=,iv:cb1aT1I1HSZjE/zzRWsDZaI4kbI71HVY+uBx0K0f3bo=,tag:XEix31wmfmDDGEzNrxfHoQ==,type:str]
+    lastmodified: "2026-06-25T02:26:12Z"
+    mac: ENC[AES256_GCM,data:rd26h47LU09Ay8UridzgtGeZJOHLvx+lYc1b75mjGzIhjPUApq/CGSf1fQFOKx9hr//dbSg2l0LdZXps+XxD9tpXbc3TgJ6UfKpFhJjbL0p2dfouqLiAg4RU69JHVG6txTTtbq6uqWyJtuYDumEDGEAUpQ2LH7kkDyWySqsDewg=,iv:jVIwyjRxSEoZPJf8pZvYW4/hclmoUsak7ruVWlm4BiE=,tag:CNjJgxnRTPp4nA+OLWeejw==,type:str]
     version: 3.13.1

--- a/roles/workloads/templates/httproute-dotfiles.yaml.j2
+++ b/roles/workloads/templates/httproute-dotfiles.yaml.j2
@@ -15,6 +15,15 @@ spec:
     - "dotfiles.{{ external_domain }}"
   rules:
     - filters:
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Strict-Transport-Security
+                value: max-age=63072000; includeSubDomains; preload
+              - name: Referrer-Policy
+                value: same-origin
+              - name: X-Content-Type-Options
+                value: nosniff
         - type: RequestRedirect
           requestRedirect:
             scheme: https


### PR DESCRIPTION
Replace the nested-subdomain hostname dev.obscura.barrelmaker.dev with the single-label devscura.barrelmaker.dev so it is covered by the existing *.barrelmaker.dev wildcard cert, avoiding the need for a separate *.obscura.barrelmaker.dev SAN (RFC 6125 wildcards match exactly one label).

Also prepend a ResponseHeaderModifier filter to the dotfiles redirect HTTPRoute so the 302 response carries the same Strict-Transport- Security, Referrer-Policy, and X-Content-Type-Options headers as the other public routes.